### PR TITLE
Fix AMI not found

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ provider "random" {}
 resource "random_pet" "sg" {}
 
 resource "aws_instance" "web" {
-  ami                    = "ami-830c94e3"
+  ami                    = "ami-890b62b3"
   instance_type          = "t2.micro"
   vpc_security_group_ids = [aws_security_group.web-sg.id]
 


### PR DESCRIPTION
The AMI on tutorial source code doesn't exist